### PR TITLE
Add support for CiviCRM Standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ For example:
  * `http://localhost/latest/civicrm-NIGHTLY-drupal6.tar.gz`
  * `http://localhost/latest/civicrm-STABLE-drupal.tar.gz`
  * `http://localhost/latest/civicrm-STABLE-wordpress.zip`
+ * `http://localhost/latest/civicrm-STABLE-standalone.zip`
  * `http://localhost/latest/civicrm-RC-joomla.zip`
 
 

--- a/src/CiviDistManagerBundle/CmsMap.php
+++ b/src/CiviDistManagerBundle/CmsMap.php
@@ -18,6 +18,7 @@ class CmsMap {
       'joomla' => 'Joomla',
       'joomla-alt' => 'Joomla',
       'l10n' => 'L10n',
+      'standalone' => 'Standalone',
       'starterkit' => 'Drupal',
     );
   }

--- a/src/CiviDistManagerBundle/Controller/BrowseController.php
+++ b/src/CiviDistManagerBundle/Controller/BrowseController.php
@@ -36,6 +36,7 @@ class BrowseController extends Controller {
         'civicrm-X.Y.Z-joomla-LATEST.zip',
         'civicrm-X.Y.Z-joomla-alt-LATEST.zip',
         'civicrm-X.Y.Z-l10n-LATEST.tar.gz',
+        'civicrm-X.Y.Z-standalone-LATEST.tgz',
         'civicrm-X.Y.Z-starterkit-LATEST.tgz',
         'civicrm-X.Y.Z-wordpress-LATEST.zip',
         'civicrm-X.Y.Z-wporg-LATEST.zip',
@@ -124,6 +125,7 @@ class BrowseController extends Controller {
       'gitBrowsers' => array(
         'civicrm-core' => 'https://github.com/civicrm/civicrm-core/commits',
         'civicrm-packages' => 'https://github.com/civicrm/civicrm-packages/commits',
+        'civicrm-standalone' => 'https://github.com/civicrm/civicrm-core/commits',
         'civicrm-joomla' => 'https://github.com/civicrm/civicrm-joomla/commits',
         'civicrm-backdrop@1.x' => 'https://github.com/civicrm/civicrm-backdrop/commits',
         'civicrm-drupal@6.x' => 'https://github.com/civicrm/civicrm-drupal/commits',

--- a/src/CiviDistManagerBundle/Controller/CheckController.php
+++ b/src/CiviDistManagerBundle/Controller/CheckController.php
@@ -94,6 +94,7 @@ class CheckController extends Controller {
         'civicrm-drupal@6.x' => 'https://github.com/civicrm/civicrm-drupal/commits',
         'civicrm-drupal@7.x' => 'https://github.com/civicrm/civicrm-drupal/commits',
         'civicrm-drupal@8.x' => 'https://github.com/civicrm/civicrm-drupal/commits',
+        'civicrm-standalone' => 'https://github.com/civicrm/civicrm-core/commits',
         'civicrm-wordpress' => 'https://github.com/civicrm/civicrm-wordpress/commits',
       ),
     ));
@@ -189,6 +190,8 @@ class CheckController extends Controller {
         // 'Joomla-Alt' => 'https://download.civicrm.org/civicrm-4.7.12-joomla-alt.zip',
         'L10n' => sprintf('%s/%s/civicrm-%s-l10n.tar.gz',
           self::STABLE_DOWNLOAD_URL, $rev, $rev),
+        'Standalone' => sprintf('%s/%s/civicrm-%s-standalone.tar.gz',
+          self::STABLE_DOWNLOAD_URL, $rev, $rev),
         'WordPress' => sprintf('%s/%s/civicrm-%s-wordpress.zip',
           self::STABLE_DOWNLOAD_URL, $rev, $rev),
       ),
@@ -200,6 +203,7 @@ class CheckController extends Controller {
         'civicrm-drupal@6.x' => array('commit' => "6.x-$rev"),
         'civicrm-drupal@7.x' => array('commit' => "7.x-$rev"),
         'civicrm-drupal@8.x' => array('commit' => "8.x-$rev"),
+        'civicrm-standalone' => array('commit' => $rev),
         'civicrm-wordpress' => array('commit' => $rev),
       ),
     );

--- a/src/CiviDistManagerBundle/LegacyRedirect.php
+++ b/src/CiviDistManagerBundle/LegacyRedirect.php
@@ -7,7 +7,7 @@ class LegacyRedirect {
     // ex: /civicrm-4.7.10-drupal.tar.gz
     // ex: https://storage.googleapis.com/civicrm/civicrm-stable/4.7.12/civicrm-4.7.12-backdrop-unstable.tar.gz
     $base = "https://storage.googleapis.com/civicrm";
-    if (preg_match(";^/civicrm-([0-9a-z\.]+)(-drupal|-joomla|-wordpress|-l10n|-back|-starter|.MD5);", $path, $matches)) {
+    if (preg_match(";^/civicrm-([0-9a-z\.]+)(-drupal|-joomla|-wordpress|-l10n|-back|-standalone|-starter|.MD5);", $path, $matches)) {
       $version = $matches[1];
       if (preg_match(';(alpha|beta);', $version)) {
         return "$base/civicrm-testing/$version$path";

--- a/src/CiviDistManagerBundle/RevDocRepository.php
+++ b/src/CiviDistManagerBundle/RevDocRepository.php
@@ -146,7 +146,7 @@ class RevDocRepository {
    *   Ex: 'Drupal' or 'Drupal6'.
    */
   protected function getTarName($file) {
-    if (!preg_match(';^civicrm-(.*)-(backdrop|drupal|drupal6|joomla|joomla-alt|starterkit|wordpress|wporg|l10n)(-[0-9]+)?\.(zip|tar.gz|tgz)$;i', $file['basename'], $matches)) {
+    if (!preg_match(';^civicrm-(.*)-(backdrop|drupal|drupal6|joomla|joomla-alt|standalone|starterkit|wordpress|wporg|l10n)(-[0-9]+)?\.(zip|tar.gz|tgz)$;i', $file['basename'], $matches)) {
       return NULL;
     }
     $cms = $matches[2];
@@ -156,6 +156,7 @@ class RevDocRepository {
       'drupal6' => 'Drupal6',
       'joomla' => 'Joomla',
       'joomla-alt' => 'JoomlaAlt',
+      'standalone' => 'Standalone',
       'starterkit' => 'StarterKit',
       'wordpress' => 'WordPress',
       'wporg' => 'WPOrg',


### PR DESCRIPTION
Related to (merged) https://github.com/civicrm/civicrm-core/pull/27104

Has been tested in prod already.

I'm not really sure why it shows for Nightly and not the RC (stable uses different code). I mostly copy-pasted what I could. (and stable builds are 404 for now, but they should soon show up, right?)